### PR TITLE
Fixed some entries not working due to one-star notation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,11 @@
 # prevent github from displaying the repository as ASM or HTML due to documentation and data files
-source/data/* linguist-vendored
-useful_documents/* linguist-documentation
-external/* linguist-vendored
+useful_documents/** linguist-documentation
+help/** linguist-documentation
+licenses/* linguist-documentation
+
+external/** linguist-vendored
+
+source/data/* linguist-generated
+
 *.lisp linguist-language=lisp
+*.s linguist-language=Assembly


### PR DESCRIPTION
To ignore all subfolders you'd need to use two stars instead of one star ([documentation](https://github.com/github/linguist/blob/master/docs/overrides.md)).
I also added assembly and the help and licenses folders as `linguist-documentation` 
and changed `source/data/` to `linguist-generated`