### PR TITLE
Rewind disable lisp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ build/#build.sh
 source/platform/gba/images.cpp
 source/platform/nds/images.cpp
 source/platform/desktop/images.cpp
+build/.cmake/*

--- a/scripts/adventure_vars.lisp
+++ b/scripts/adventure_vars.lisp
@@ -19,3 +19,5 @@
 (if (equal (difficulty) 0)
     (setvar "powerdown_allowed" 1)
     (setvar "powerdown_allowed" 0))
+    
+(setvar "rewind_disabled" 0)

--- a/scripts/challenges/challenge.lisp
+++ b/scripts/challenges/challenge.lisp
@@ -7,6 +7,7 @@
 (if (bound? 'challenge-hint) (unbind 'challenge-hint))
 
 (setvar "powerdown_allowed" 0)
+(setvar "rewind_disabled" 1)
 
 (gc)
 

--- a/scripts/event/hostile.lisp
+++ b/scripts/event/hostile.lisp
@@ -4,6 +4,7 @@
 ;;; Entry point for loading hostile enemy scenarios
 ;;;
 
+(setvar "rewind_disabled" 1)
 
 (eval-file "/scripts/reset_hooks.lisp")
 (eval-file "/scripts/event/check_zone.lisp")

--- a/scripts/event/hostile.lisp
+++ b/scripts/event/hostile.lisp
@@ -4,7 +4,6 @@
 ;;; Entry point for loading hostile enemy scenarios
 ;;;
 
-(setvar "rewind_disabled" 1)
 
 (eval-file "/scripts/reset_hooks.lisp")
 (eval-file "/scripts/event/check_zone.lisp")

--- a/scripts/event/shop/shop.lisp
+++ b/scripts/event/shop/shop.lisp
@@ -5,6 +5,7 @@
 
 (eval-file "/scripts/reset_hooks.lisp")
 (eval-file "/scripts/event/check_zone.lisp")
+(setvar "rewind_disabled" 1)
 
 
 (adventure-log-add 49 '())

--- a/scripts/event/skyland_forever.lisp
+++ b/scripts/event/skyland_forever.lisp
@@ -22,3 +22,4 @@
 (flag-show (player) 0)
 
 (setvar "powerdown_allowed" 0)
+(setvar "rewind_disabled" 0)

--- a/scripts/reset_hooks.lisp
+++ b/scripts/reset_hooks.lisp
@@ -35,6 +35,8 @@
 (if (not (bound? 'friendlies-seen))
     (setq friendlies-seen '()))
 
+(setvar "rewind_disabled" 0)
+
 
 ;; I try not to run the gc manually. But we just detached a bunch of callbacks
 ;; that were storing potentially large functions. The collector possibly going

--- a/scripts/sandbox/new.lisp
+++ b/scripts/sandbox/new.lisp
@@ -96,3 +96,4 @@
 (unbind 'conf 'mkch)
 
 (setvar "powerdown_allowed" 1)
+(setvar "rewind_disabled" 0)

--- a/scripts/tutorials/tutorials.lisp
+++ b/scripts/tutorials/tutorials.lisp
@@ -5,6 +5,8 @@
 
 (eval-file "/scripts/reset_hooks.lisp")
 (setvar "powerdown_allowed" 1)
+(setvar "rewind_disabled" 0)
+
 
 ;; NOTE: the list should not exceed 64 tutorials.
 

--- a/source/skyland/scene/fadeInScene.cpp
+++ b/source/skyland/scene/fadeInScene.cpp
@@ -156,8 +156,6 @@ ScenePtr FadeInScene::update(Time delta)
                 PLATFORM.speaker().stream_music(
                     APP.environment().music()->c_str(), 0);
             }
-        } else if (node.type_ == WorldGraph::Node::Type::shop) {
-            APP.time_stream().enable_pushes(false);
         }
 
         if (rewind_disabled) {

--- a/source/skyland/scene/fadeInScene.cpp
+++ b/source/skyland/scene/fadeInScene.cpp
@@ -41,12 +41,13 @@
 #include "skyland/scene_pool.hpp"
 #include "skyland/skyland.hpp"
 #include "skyland/timeStreamEvent.hpp"
-
+#include "skyland/sharedVariable.hpp"
 
 
 namespace skyland
 {
 
+SHARED_VARIABLE(rewind_disabled);
 
 
 void generate_snow(Island& isle)
@@ -156,6 +157,10 @@ ScenePtr FadeInScene::update(Time delta)
                     APP.environment().music()->c_str(), 0);
             }
         } else if (node.type_ == WorldGraph::Node::Type::shop) {
+            APP.time_stream().enable_pushes(false);
+        }
+
+        if (rewind_disabled) {
             APP.time_stream().enable_pushes(false);
         }
 


### PR DESCRIPTION
Currently, the rewind feature can be disabled or enabled via a function, but more testing is required.